### PR TITLE
Increase container detection as running (24h)

### DIFF
--- a/Dockerfile.configurator
+++ b/Dockerfile.configurator
@@ -10,7 +10,7 @@ RUN apt-get update && \
       python-pip && \
     pip install \
       simplemysql \
-      pycurl \
+      pycurl==7.43.0.3 \
       pyzabbix && \
     apt-get clean
 

--- a/configuration/zabbix_docker_template.xml
+++ b/configuration/zabbix_docker_template.xml
@@ -157,7 +157,7 @@ Current template is compartible only with zabbix agent module, that can be found
                     <snmp_community/>
                     <snmp_oid/>
                     <key>docker.discovery</key>
-                    <delay>3540</delay>
+                    <delay>86400</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>


### PR DESCRIPTION
Hi,

Increased container detection period to avoid monitoring of instances with short life time (launched for monitoring purposes, etc)